### PR TITLE
feat: add arg to set the docker container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ steps:
   with:
     host port: 3800 # Optional, default value is 3306. The port of host
     container port: 3307 # Optional, default value is 3306. The port of container
+    container name: 'some_test_mysql' # Optional, default value is 'some_mysql'. The name of container
     character set server: 'utf8' # Optional, default value is 'utf8mb4'. The '--character-set-server' option for mysqld
     collation server: 'utf8_general_ci' # Optional, default value is 'utf8mb4_general_ci'. The '--collation-server' option for mysqld
     mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'The port of container'
     required: false
     default: 3306
+  container name:
+    description: 'The name of container'
+    required: false
+    default: 'some_mysql'
   character set server:
     description: '--character-set-server - The character set of MySQL server'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker_run="docker run"
+docker_run="docker run --name $INPUT_CONTAINER_NAME"
 
 if [ -n "$INPUT_MYSQL_ROOT_PASSWORD" ]; then
   echo "Root password not empty, use root superuser"


### PR DESCRIPTION
I have a case where I have to import a sql file into the database after set-up MySQL, but I don't have the container name to execute the `docker exec -i my_mysql ...` command.

I think it is useful to have an argument to define the name of the container.