### PR TITLE
Add "use tmpfs" and "tmpfs size" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ steps:
     mysql root password: ${{ secrets.RootPassword }} # Required if "mysql user" is empty, default is empty. The root superuser password
     mysql user: 'developer' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
     mysql password: ${{ secrets.DatabasePassword }} # Required if "mysql user" exists. The password for the "mysql user"
+    use tmpfs: true # Optional, default value is false. Mounts /var/lib/mysql to tmpfs (i.e. in RAM) for increased performance
+    tmpfs size: '2048M' # Optional, default value is '1024M'. Desired size of above-mentioned tmpfs volume
 ```
 
 If want bind MySQL host port to 3306, please see [The Default MySQL](#the-default-mysql).

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,14 @@ inputs:
     description: 'MYSQL_PASSWORD - specified superuser password which user is power for created database'
     required: false
     default: ''
+  use tmpfs:
+    description: "Whether or not to use Docker's tmpfs feature for MySQL's storage"
+    required: false
+    default: false
+  tmpfs size:
+    description: "Desired size of tmpfs volume"
+    required: false
+    default: "1024M"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,10 @@
 
 docker_run="docker run"
 
+if [ "$INPUT_USE_TMPFS" == "true" ]; then
+  docker_run="$docker_run --tmpfs /var/lib/mysql:rw,noexec,nosuid,size=$INPUT_TMPFS_SIZE"
+fi
+
 if [ -n "$INPUT_MYSQL_ROOT_PASSWORD" ]; then
   echo "Root password not empty, use root superuser"
 


### PR DESCRIPTION
This PR adds `use tmpfs` and `tmpfs size` options.  This allows the MySQL container's data to be run in RAM for a massive performance increase.  It works especially well in CI environments where database fixtures are recreated for each and every test case.