### PR TITLE
Add support for mariadb + default authentication plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['10.x']
+        mysql-variant: ['mysql', 'mariadb']
 
     steps:
     - uses: actions/checkout@v1
@@ -27,6 +28,7 @@ jobs:
     - name: Set up MySQL 5.7
       uses: mirromutth/mysql-action@master
       with:
+        mysql variant: ${{ matrix.mysql-variant }}
         mysql version: 5.7
         mysql database: test
         mysql root password: ${{ secrets.DatabasePassword }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,14 @@ jobs:
       matrix:
         node-version: ['10.x']
         mysql-variant: ['mysql', 'mariadb']
+        mysql-version: ['5.7']
+        include:
+          - node-version: '10.x'
+            mysql-variant: 'mysql'
+            mysql-version: '8.0'
+          - node-version: '10.x'
+            mysql-variant: 'mariadb'
+            mysql-version: '10.3'
 
     steps:
     - uses: actions/checkout@v1
@@ -25,11 +33,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Set up MySQL 5.7
+    - name: Set up ${{ matrix.mysql-variant }} ${{ matrix.mysql-version }}
       uses: mirromutth/mysql-action@master
       with:
         mysql variant: ${{ matrix.mysql-variant }}
-        mysql version: 5.7
+        mysql version: ${{ matrix.mysql-version }}
         mysql database: test
         mysql root password: ${{ secrets.DatabasePassword }}
     - name: npm install, build, and test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Set up ${{ matrix.mysql-variant }} ${{ matrix.mysql-version }}
-      uses: mirromutth/mysql-action@master
+      uses: ./
       with:
         mysql variant: ${{ matrix.mysql-variant }}
         mysql version: ${{ matrix.mysql-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
             mysql-version: '10.3'
           - node-version: '10.x'
             mysql-variant: 'mariadb'
+            mysql-version: '5.7'
+          - node-version: '10.x'
+            mysql-variant: 'mariadb'
             mysql-version: '8.0'
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,15 @@ jobs:
     strategy:
       matrix:
         node-version: ['10.x']
-        include:
+        mysql-variant: ['mysql', 'mariadb']
+        mysql-version: ['5.7', '8.0', '10.3']
+        exclude:
           - node-version: '10.x'
             mysql-variant: 'mysql'
-            mysql-version: '5.7'
-          - node-version: '10.x'
-            mysql-variant: 'mysql'
-            mysql-version: '8.0'
+            mysql-version: '10.3'
           - node-version: '10.x'
             mysql-variant: 'mariadb'
-            mysql-version: '10.3'
+            mysql-version: '8.0'
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,10 @@ jobs:
     strategy:
       matrix:
         node-version: ['10.x']
-        mysql-variant: ['mysql', 'mariadb']
-        mysql-version: ['5.7']
         include:
+          - node-version: '10.x'
+            mysql-variant: 'mysql'
+            mysql-version: '5.7'
           - node-version: '10.x'
             mysql-variant: 'mysql'
             mysql-version: '8.0'

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ steps:
     mysql root password: ${{ secrets.RootPassword }} # Required if "mysql user" is empty, default is empty. The root superuser password
     mysql user: 'developer' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
     mysql password: ${{ secrets.DatabasePassword }} # Required if "mysql user" exists. The password for the "mysql user"
+    authentication plugin: 'mysql_old_password' # Optional, default value is "mysql_native_password". This was the standard plugin in MySQL before 8.0 version.  
 ```
 
 If want bind MySQL host port to 3306, please see [The Default MySQL](#the-default-mysql).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ steps:
     container port: 3307 # Optional, default value is 3306. The port of container
     character set server: 'utf8' # Optional, default value is 'utf8mb4'. The '--character-set-server' option for mysqld
     collation server: 'utf8_general_ci' # Optional, default value is 'utf8mb4_general_ci'. The '--collation-server' option for mysqld
+    mysql variant: 'mysql' # Optional, default value is 'mysql'. Change to mariadb, if needed.
     mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL
     mysql database: 'some_test' # Optional, default value is "test". The specified database which will be create
     mysql root password: ${{ secrets.RootPassword }} # Required if "mysql user" is empty, default is empty. The root superuser password

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: 'utf8mb4_general_ci'
   mysql variant:
-    description: 'Variant / fork of MySQL. Values: mysql, mariadb.'
+    description: 'Variant (fork) of MySQL. Values: mysql, mariadb.'
     required: false
     default: 'mysql'
   mysql version:
@@ -45,6 +45,10 @@ inputs:
     description: 'MYSQL_PASSWORD - specified superuser password which user is power for created database'
     required: false
     default: ''
+  authentication plugin:
+    description: 'Set authentication plugin. Login/password is used as default. Changes default behaviour of MySQL 8.0+, where `caching_sha2_password` is a default value.'
+    required: false
+    default: 'mysql_native_password'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: '--collation-server - The character collation of MySQL server'
     required: false
     default: 'utf8mb4_general_ci'
+  mysql variant:
+    description: 'Variant / fork of MySQL. Values: mysql, mariadb.'
+    required: false
+    default: 'mysql'
   mysql version:
     description: 'Version of MySQL to use'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ if [ -n "$INPUT_MYSQL_DATABASE" ]; then
   docker_run="$docker_run -e MYSQL_DATABASE=$INPUT_MYSQL_DATABASE"
 fi
 
-docker_run="$docker_run -d -p $INPUT_HOST_PORT:$INPUT_CONTAINER_PORT mysql:$INPUT_MYSQL_VERSION --port=$INPUT_CONTAINER_PORT"
+docker_run="$docker_run -d -p $INPUT_HOST_PORT:$INPUT_CONTAINER_PORT $INPUT_MYSQL_VARIANT:$INPUT_MYSQL_VERSION --port=$INPUT_CONTAINER_PORT"
 docker_run="$docker_run --character-set-server=$INPUT_CHARACTER_SET_SERVER --collation-server=$INPUT_COLLATION_SERVER"
 
 sh -c "$docker_run"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,6 @@ if [ -n "$INPUT_MYSQL_DATABASE" ]; then
 fi
 
 docker_run="$docker_run -d -p $INPUT_HOST_PORT:$INPUT_CONTAINER_PORT $INPUT_MYSQL_VARIANT:$INPUT_MYSQL_VERSION --port=$INPUT_CONTAINER_PORT"
-docker_run="$docker_run --character-set-server=$INPUT_CHARACTER_SET_SERVER --collation-server=$INPUT_COLLATION_SERVER"
+docker_run="$docker_run --character-set-server=$INPUT_CHARACTER_SET_SERVER --collation-server=$INPUT_COLLATION_SERVER --default-authentication-plugin=$INPUT_AUTHENTICATION_PLUGIN"
 
 sh -c "$docker_run"


### PR DESCRIPTION
This PR:

- adds support for mariadb images as well
- adds parameter authentication plugin with default value 'mysql_native_password'.
The thing is, mysql 8.0+ changed its default authentication plugin from 'mysql_native_password' to 'caching_sha2_password' causing 'The server requested authentication method unknown to the client [caching_sha2_password]' error for many applications. Setting the default value to 'mysql_native_password' enforces the standard login/password authentication even for mysql 8.0+ versions.

I've also added the tests to cover new functionality.