### PR TITLE
Fixed Docker client API version mismatch on newer CI runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:stable
+FROM docker:cli
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ steps:
     mysql root password: ${{ secrets.RootPassword }} # Required if "mysql user" is empty, default is empty. The root superuser password
     mysql user: 'developer' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
     mysql password: ${{ secrets.DatabasePassword }} # Required if "mysql user" exists. The password for the "mysql user"
+    use tmpfs: true # Optional, default value is false. Mounts /var/lib/mysql to tmpfs (i.e. in RAM) for increased performance
+    tmpfs size: '2048M' # Optional, default value is '1024M'. Desired size of above-mentioned tmpfs volume
 ```
 
 If want bind MySQL host port to 3306, please see [The Default MySQL](#the-default-mysql).

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,14 @@ inputs:
     description: 'Set authentication plugin. Login/password is used as default. Changes default behaviour of MySQL 8.0+, where `caching_sha2_password` is a default value.'
     required: false
     default: 'mysql_native_password'
+  use tmpfs:
+    description: "Whether or not to use Docker's tmpfs feature for MySQL's storage"
+    required: false
+    default: true
+  tmpfs size:
+    description: "Desired size of tmpfs volume"
+    required: false
+    default: "3072M"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   collation server:
     description: '--collation-server - The character collation of MySQL server'
     required: false
-    default: 'utf8mb4_general_ci'
+    default: 'utf8mb4_0900_ai_ci'
   mysql version:
     description: 'Version of MySQL to use'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'MYSQL_PASSWORD - specified superuser password which user is power for created database'
     required: false
     default: ''
+  authentication plugin:
+    description: 'Set authentication plugin. Login/password is used as default. Changes default behaviour of MySQL 8.0+, where `caching_sha2_password` is a default value.'
+    required: false
+    default: 'mysql_native_password'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 docker_run="docker run"
 
-if [ "$INPUT_USE_TMPFS" == "true" ]; then
+if [ "$INPUT_USE_TMPFS" = "true" ]; then
   echo "Using tmpfs"
   docker_run="$docker_run --tmpfs /var/lib/mysql:rw,noexec,nosuid,size=$INPUT_TMPFS_SIZE"
 fi
@@ -50,7 +50,7 @@ fi
 
 MAX_TRIES=120
 TRIES=0
-while ! docker exec mysql mysql -h"127.0.0.1" -P"$INPUT_HOST_PORT" -u"$HEALTHCHECK_USER" -p"$HEALTHCHECK_PASS" -e "SELECT 1" $INPUT_MYSQL_DATABASE &> /dev/null; do
+while ! docker exec mysql mysql -h"127.0.0.1" -P"$INPUT_HOST_PORT" -u"$HEALTHCHECK_USER" -p"$HEALTHCHECK_PASS" -e "SELECT 1" $INPUT_MYSQL_DATABASE > /dev/null 2>&1; do
     TRIES=$((TRIES + 1))
     if [ "$TRIES" -ge "$MAX_TRIES" ]; then
       echo "MySQL failed to start after ${MAX_TRIES}s"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 docker_run="docker run"
 
+if [ "$INPUT_USE_TMPFS" == "true" ]; then
+  echo "Using tmpfs"
+  docker_run="$docker_run --tmpfs /var/lib/mysql:rw,noexec,nosuid,size=$INPUT_TMPFS_SIZE"
+fi
+
 HEALTHCHECK_USER=""
 HEALTHCHECK_PASS=""
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,6 @@ if [ -n "$INPUT_MYSQL_DATABASE" ]; then
 fi
 
 docker_run="$docker_run -d -p $INPUT_HOST_PORT:$INPUT_CONTAINER_PORT mysql:$INPUT_MYSQL_VERSION --port=$INPUT_CONTAINER_PORT"
-docker_run="$docker_run --character-set-server=$INPUT_CHARACTER_SET_SERVER --collation-server=$INPUT_COLLATION_SERVER"
+docker_run="$docker_run --character-set-server=$INPUT_CHARACTER_SET_SERVER --collation-server=$INPUT_COLLATION_SERVER --default-authentication-plugin=$INPUT_AUTHENTICATION_PLUGIN"
 
 sh -c "$docker_run"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,14 @@
 
 docker_run="docker run"
 
+HEALTHCHECK_USER=""
+HEALTHCHECK_PASS=""
+
 if [ -n "$INPUT_MYSQL_ROOT_PASSWORD" ]; then
   echo "Root password not empty, use root superuser"
+
+  HEALTHCHECK_USER="root"
+  HEALTHCHECK_PASS="$INPUT_MYSQL_ROOT_PASSWORD"
 
   docker_run="$docker_run -e MYSQL_ROOT_PASSWORD=$INPUT_MYSQL_ROOT_PASSWORD"
 elif [ -n "$INPUT_MYSQL_USER" ]; then
@@ -13,6 +19,9 @@ elif [ -n "$INPUT_MYSQL_USER" ]; then
   fi
 
   echo "Use specified user and password"
+
+  HEALTHCHECK_USER="$INPUT_MYSQL_USER"
+  HEALTHCHECK_PASS="$INPUT_MYSQL_PASSWORD"
 
   docker_run="$docker_run -e MYSQL_RANDOM_ROOT_PASSWORD=true -e MYSQL_USER=$INPUT_MYSQL_USER -e MYSQL_PASSWORD=$INPUT_MYSQL_PASSWORD"
 else
@@ -26,7 +35,14 @@ if [ -n "$INPUT_MYSQL_DATABASE" ]; then
   docker_run="$docker_run -e MYSQL_DATABASE=$INPUT_MYSQL_DATABASE"
 fi
 
-docker_run="$docker_run -d -p $INPUT_HOST_PORT:$INPUT_CONTAINER_PORT mysql:$INPUT_MYSQL_VERSION --port=$INPUT_CONTAINER_PORT"
+docker_run="$docker_run -d --name mysql -p $INPUT_HOST_PORT:$INPUT_CONTAINER_PORT mysql:$INPUT_MYSQL_VERSION --port=$INPUT_CONTAINER_PORT"
 docker_run="$docker_run --character-set-server=$INPUT_CHARACTER_SET_SERVER --collation-server=$INPUT_COLLATION_SERVER --default-authentication-plugin=$INPUT_AUTHENTICATION_PLUGIN"
 
 sh -c "$docker_run"
+
+while ! docker exec mysql mysql -h"127.0.0.1" -P"$INPUT_HOST_PORT" -u"$HEALTHCHECK_USER" -p"$HEALTHCHECK_PASS" -e "SELECT 1" $INPUT_MYSQL_DATABASE &> /dev/null; do
+    echo "MySQL is unavailable - sleeping"
+    sleep 1
+done
+
+echo "MySQL is available"


### PR DESCRIPTION
## Summary
- Updated `docker:stable` (frozen Dec 2020, API v1.40) to `docker:cli` (Docker 29.x) — newer GitHub Actions runners require minimum API v1.44, causing `docker run` to fail silently and the health check to spin for 5 minutes until timeout
- Added fail-fast on `docker run` failure instead of proceeding to health check
- Bounded health check loop to 120 attempts with container crash detection and `docker logs` output for debugging

## Context
This has been causing flaky CI failures in [TryGhost/Ghost](https://github.com/TryGhost/Ghost/actions/runs/21953721404/job/63411946632) — the error is:
```
docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```

The failures are intermittent because GitHub is rolling out newer Docker daemons across runners gradually.